### PR TITLE
Change create entry

### DIFF
--- a/connectdb.js
+++ b/connectdb.js
@@ -2,14 +2,6 @@ const { Sequelize } = require('sequelize');
 
 const { dbName, dbUser, dbPass, dbPort } = require('./configdb');
 
-
-// Issue: Doesn't seem to work on other computers
-// Instantiate Sequelize, connect to postgres database
-// Right now it doesn't create a database, it uses one created prior.
-// let dbName = 'todoList';
-// const db = new Sequelize('postgres://localhost/' + dbName);
-
-// New test
 const db = new Sequelize(dbName, dbUser, dbPass, {
     host: 'localhost',
     dialect: 'postgres',

--- a/index.js
+++ b/index.js
@@ -23,15 +23,12 @@ app.get("/getAllEntries", async (req, res) => {
 });
 
 app.post("/createEntry", async (req, res) => {
-  let entryText = req.body;
+  let entry = req.body;
   //console.log(entryText);
   const createEntry = Entry.create({
-    completed: entry.completed,
     text: entry.text,
     priority: entry.priority,
     list_id: entry.list_id,
-    entry_id: entry.entry_id,
-    color: entry.color,
   });
 
   res.send("created entry");

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const express = require("express");
 const app = express();
-const port = 3000;
+const port = 3001;
 
 const { Entry, syncEntry } = require("./models/entry");
 

--- a/index.js
+++ b/index.js
@@ -23,7 +23,8 @@ app.get("/getAllEntries", async (req, res) => {
 });
 
 app.post("/createEntry", async (req, res) => {
-  let entry = req.query;
+  let entryText = req.body;
+  //console.log(entryText);
   const createEntry = Entry.create({
     completed: entry.completed,
     text: entry.text,

--- a/models/entry.js
+++ b/models/entry.js
@@ -24,6 +24,8 @@ const Entry = db.define('entry', {
     },
     entry_id: {
         type: DataTypes.INTEGER,
+        primaryKey: true,
+        autoIncrement: true,
         allowNull: false
     },
     color: {


### PR DESCRIPTION
Changed port to 3001 so the frontend doesn't conflict with backend port

Modified entry.js
- made entry_id primary key and use autoIncrement, no need to manually enter a unique number

Modified index.js
- /createEntry
- now request body is collected to create an Entry instead of query
- Removed fields that would be default values, left 3 fields for manual input
  -  text
  - priority
  - list_id

Right now, just need to delete database first, recreate it, sync it, then test /createEntry

Source: https://sequelize.org/docs/v6/other-topics/legacy/#primary-keys 