### PR TITLE
Add relationships and moved sync to db

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,9 @@ const express = require("express");
 const app = express();
 const port = 3001;
 
-const { Entry, syncEntry } = require("./models/entry");
-const { List, syncList } = require("./models/list");
+const { db } = require("./connectdb");
+const { Entry } = require("./models/entry");
+const { List } = require("./models/list");
 
 // built-in body parser
 app.use(express.json());
@@ -13,9 +14,10 @@ app.get("/", (req, res) => {
 });
 
 app.get("/dbSync", async (req, res) => {
-  syncEntry();
-  syncList();
-  res.send("synced models with db");
+  List.hasMany(Entry, {sourceKey: "list_id", foreignKey: "list_id"});
+  Entry.belongsTo(List, {foreignKey: "list_id"});
+  await db.sync({force: true});
+  res.send("Synced models with db");
 });
 
 // For entries

--- a/models/entry.js
+++ b/models/entry.js
@@ -19,7 +19,7 @@ const Entry = db.define('entry', {
     },
     list_id: {
         type: DataTypes.INTEGER,
-        defaultValue: 0,
+        defaultValue: 1,
         allowNull: false
     },
     entry_id: {
@@ -40,9 +40,4 @@ const Entry = db.define('entry', {
     }
 });
 
-async function syncEntry() {
-    // use alter to update models in the db when changed
-    await Entry.sync({alter: true});
-}
-
-module.exports = { Entry, syncEntry };
+module.exports = { Entry };

--- a/models/list.js
+++ b/models/list.js
@@ -8,11 +8,6 @@ const List = db.define('list', {
         autoIncrement: true,
         allowNull: false
     },
-    entry_ids: {
-        type: DataTypes.ARRAY(DataTypes.INTEGER),
-        defaultValue: [],
-        allowNull: false
-    },
     date_created: {
         type: DataTypes.DATE,
         defaultValue: DataTypes.NOW,
@@ -20,9 +15,4 @@ const List = db.define('list', {
     }
 });
 
-async function syncList() {
-    // use alter to update models in the db when changed
-    await List.sync({alter: true});
-}
-
-module.exports = { List, syncList };
+module.exports = { List };


### PR DESCRIPTION
Modified index.js
- /dbSync
  - the db is synced so all models are synced at once
  - added associations hasMany/belongsTo for List/Entry

Modified list.js
- removed syncList

Modified entry.js
- removed syncEntry

Source:
- https://sequelize.org/docs/v6/core-concepts/model-basics/#synchronizing-all-models-at-once