### PR TITLE
implement /getEntriesFromList

### DIFF
--- a/index.js
+++ b/index.js
@@ -123,6 +123,18 @@ app.get("/getList/:list_id", async (req, res) => {
 
 });
 
+app.get("/getEntriesFromList/:list_id", async (req, res) => {
+  // if exit server, then association is not kept, so added these two lines below for that issue
+  List.hasMany(Entry, {sourceKey: "list_id", foreignKey: "list_id"});
+  Entry.belongsTo(List, {foreignKey: "list_id"});
+  const list_id = req.params.list_id;
+  const data = await List.findByPk(Number(list_id), {
+    include: Entry
+  });
+
+  res.send(JSON.stringify(data, null, 2));
+});
+
 app.post("/createList", async (req, res) => {
 
 });


### PR DESCRIPTION
Modified index.js
- /getEntriesFromList/:list_id
- give a list id and get the list along with its entries

Association is used in the /getEntriesFromList route because it was reset everytime the express app is exited.

Sources: 
- Helped me understand 1:N a little more
- https://sebhastian.com/sequelize-hasmany/
- For source key / foreign key
- https://sequelize.org/docs/v6/core-concepts/assocs/#for-hasone-and-hasmany-relationships